### PR TITLE
Raise a more verbose error message if vacuum type is not supported

### DIFF
--- a/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/tuya.py
+++ b/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/tuya.py
@@ -2,7 +2,7 @@ import datetime
 import hmac
 import requests
 
-from .const import ServerError, ClientIDError, ClientSecretError, DeviceIDError
+from .const import ServerError, ClientIDError, ClientSecretError, DeviceIDError, NotSupportedError
 
 def _get_sign(client_id: str, secret_key: str, url: str, t: int, token: str):
     empty_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -66,5 +66,8 @@ def get_download_link(
             raise DeviceIDError("Invalid Device ID")
         else:
             raise RuntimeError("Request failed - Response: ", response)
+
+    if not response["result"]:
+        raise NotSupportedError("Vacuum not supported: API returned no realtime maps")
 
     return response


### PR DESCRIPTION
As mentioned on #22:

>Unfortunately my vacuum (Kogan G50) isn't supported, as the following result object is returned from the `/v1.0/users/sweepers/file/{{device_id}}/realtime-map` endpoint (also tested using postman):

```json
{
    "result": [],
    "success": true,
    "t": 1705627940473,
    "tid": "96969c6fb66a11eeb846e2ba4cc47aff"
}
```

> Looks like my Robot Vac returns an empty result (but no error code), so it doesn't seem to be available.

This PR adds a slightly more verbose error message if a vacuum is not supported because there are no vacuum map results form the Tuya API.