### PR TITLE
Add support for compressed path data

### DIFF
--- a/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/common.py
+++ b/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/common.py
@@ -36,7 +36,7 @@ def decode_header(header: str):
         "pileY": maxmin[8],
         "totalcount": int(header[36:44], 16),
         "compressbeforelength": int(header[36:44], 16),
-        "compressafterlenght": maxmin[11],
+        "compressafterlength": maxmin[11],
         "calibrationPoints": [{
             'vacuum': {'x': 0, 'y': 0}, 
             'map': {'x': 0.0, 'y': -0.0}

--- a/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/const.py
+++ b/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/const.py
@@ -1,4 +1,5 @@
 BYTE_HEADER_LENGHT_PATH_V1 = 26
+is_Lz4 = True
 
 bitmapTypeHexMap = {
   '00': '00', # Cleaning point

--- a/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/main.py
+++ b/custom_components/tuya_cloud_map_extractor/tuya_vacuum_map_extractor/main.py
@@ -48,7 +48,7 @@ def parse_path(response: requests.models.Response, scale=2.0, header={}):
         path_data = decode_path_custom0(data, header)
     except JSONDecodeError:
         data = response.content.hex()
-        path_data = decode_path_v1(data)
+        path_data = decode_path_v1(data, header)
     
     coords = []
     for coord in path_data:


### PR DESCRIPTION
This adds support for compressed path data, such as used by the Lubluelu SL60D.
I haven't tested the changes to confirm they do not break on devices using non compressed data (I don't have one).
The way I handle the originX and originY offsets differs to the panel-demo reference code, but I think any other way would require more changes to the map rendering.